### PR TITLE
Honor $CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,4 +57,4 @@ target_link_libraries (
   ${TARGET}
 )
 
-install (TARGETS ${TARGET} DESTINATION "/usr/local/bin")
+install (TARGETS ${TARGET} DESTINATION bin)


### PR DESCRIPTION
Instead of hard-coding /usr/local/bin, just pass “bin” and let CMake put
together the final directory using $CMAKE_INSTALL_PREFIX.